### PR TITLE
Add Target Number feature to dice rolling code.

### DIFF
--- a/scripts/dice.coffee
+++ b/scripts/dice.coffee
@@ -16,6 +16,7 @@
 #                                Exploding Dice
 #                                Keep / Drop Dice
 #                                Rerolling Dice (only supports < and >)
+#                                Target Number / Successes
 #   hubot roll <x>dF - roll x fudge dice, each of which has +, +, 0, 0, -, and - sides.
 #
 # Author:
@@ -48,7 +49,7 @@ module.exports = (robot) ->
     else if dice > 100
       "I'm not going to roll more than 100 dice for you."
     else
-      report modifier, roll(dice, sides, meta_modifiers)
+      report modifier, roll(dice, sides, meta_modifiers), meta_modifiers['success_func']
     msg.reply answer
     
   robot.respond /roll (\d+)dF([\+-]\d+)?/i, (msg) ->
@@ -60,20 +61,28 @@ module.exports = (robot) ->
       report modifier, fudgeRoll dice
     msg.reply answer
 
-report = (modifier, results) ->
+report = (modifier, results, success_func) ->
   if results?
     switch results.length
       when 0
         "I didn't roll any dice."
       when 1
-        total = results[0]
+        if success_func?
+          total = if success_func(results[0]) then 'success' else 'failure'
+        else
+          total = results[0]
         answer = "I rolled a #{total}."
         if not isNaN(modifier)
           answer += modified total, modifier
         else
           answer
       else
-        total = results.reduce (x, y) -> x + y
+        if success_func?
+          num_total = results.reduce ((x, y) -> if success_func(y) then x + 1 else x), 0
+          total = "#{num_total} success#{'es' if num_total != 1}"
+        else
+          total = results.reduce (x, y) -> x + y
+
         answer = if results.length < 10
           finalComma = if (results.length > 2) then "," else ""
           last = results.pop()
@@ -151,7 +160,9 @@ fudge = ->
 
 # Parse the modifier string and return a more useful object
 parse_mods = (data) ->
-  result = {}
+  result = {
+    'success_func': undefined
+  }
 
   if not data
     return result
@@ -199,6 +210,20 @@ parse_mods = (data) ->
             'lt': reroll_lt,
             'gt': reroll_gt
           }
+        data = data[match[0].length..]
+
+      # Success / Failure
+      when '>', '<'
+        match = data.match(/^(<|>)(\d+)?/)
+        success = parseInt match[2]
+
+        if match[1] == '>'
+          result['success_func'] = (x) ->
+            return x >= success
+        if match[1] == '<'
+          result['success_func'] = (x) ->
+            return x <= success
+
         data = data[match[0].length..]
 
       # This suggests we have unparseable data in our mod string.

--- a/tests/dice_test.coffee
+++ b/tests/dice_test.coffee
@@ -191,3 +191,36 @@ describe 'when user rolls', ->
 
     it 'should have a single, low result', ->
       expect(room.messages[1][1]).to.match /I rolled a 1/
+
+  context 'and specifies a success threshold', ->
+    beforeEach ->
+      random_stub = stub(Math, 'random')
+      random_stub.onCall(0).returns(0.99) # 10
+      random_stub.onCall(1).returns(0.6) # 7
+      random_stub.onCall(2).returns(0.4) # 5
+      random_stub.onCall(3).returns(0.4) # 5
+      random_stub.onCall(4).returns(0) # 1
+      random_stub.onCall(5).returns(0) # 1
+
+    afterEach ->
+      random_stub.restore()
+
+    it 'should have 2 successes at >= 7', ->
+      room.user.say 'alice', '@hubot roll 6d10>7'
+      expect(room.messages[1][1]).to.match /2 successes./
+
+    it 'should have 4 successes at <= 5', ->
+      room.user.say 'alice', '@hubot roll 6d10<5'
+      expect(room.messages[1][1]).to.match /4 successes./
+
+    it 'should have 1 success at >= 9', ->
+      room.user.say 'alice', '@hubot roll 6d10>9'
+      expect(room.messages[1][1]).to.match /1 success./
+
+    it 'should have 1 success with 1d10>9', ->
+      room.user.say 'alice', '@hubot roll 1d10>9'
+      expect(room.messages[1][1]).to.match /I rolled a success./
+
+    it 'should have a failure with 1d10<9', ->
+      room.user.say 'alice', '@hubot roll 1d10<9'
+      expect(room.messages[1][1]).to.match /I rolled a failure./


### PR DESCRIPTION
This lets you specify a value (DC, difficulty, success target, whatever) and report over/under that as a 'success'.

Because we must have the most sophisticated chat-bot dicerolling system EVER.