### PR TITLE
Now, with re-tweets

### DIFF
--- a/scripts/twitter.coffee
+++ b/scripts/twitter.coffee
@@ -1,6 +1,19 @@
 t = require '../lib/twitter'
 
 module.exports = (robot) ->
+  robot.respond /(?:retweet|rt|retwat)\s+(.+$)/i, (msg) ->
+    tid = msg.match[1].trim()
+    tid = if tid.match(/^\d+$/)
+        tid
+      else if (info = tid.match /twitter.com\/\w+\/status+\/(\d+)/)
+        info[1]
+
+    return msg.reply "That's not a fucking tweet, moron" if not tid
+    t.client.post "statuses/retweet/#{tid}", {}, (err, tweet, response) ->
+      return msg.reply "No, because #{err}" if err
+      msg.reply "Fine, did it."
+
+
   robot.respond /tweet(\s+(me)?)?\s+(.{3,})$/i, (msg) ->
     who = msg.message.user.name or "Some-Idiot"
     what = msg.match[3].trim()


### PR DESCRIPTION
This adds .rt <tweet> as a command to RT the tweet ID or URL to our account.

Because it's useful or something.