### PR TITLE
Redact multiple times per line

### DIFF
--- a/scripts/ayp.coffee
+++ b/scripts/ayp.coffee
@@ -96,13 +96,13 @@ filterName = (name) ->
 # Make any changes required to the text
 filterText = (text) ->
   # Urls are secret. Not for you. Not for anyone.
-  text = text.replace(/(https?:\/\/[^\s]+)/, "[redacted]")
+  text = text.replace(/(https?:\/\/[^\s]+)/g, "[redacted]")
 
   # Emails 'R' Secret
-  text = text.replace(/([^@\s]+@)[^@\s]+\.[^@\s]+/, "$1[redacted]")
+  text = text.replace(/([^@\s]+@)[^@\s]+\.[^@\s]+/g, "$1[redacted]")
   
   # Let users redact shit too
-  text = text.replace(/\[[^\]]*\]/, "[redacted]")
+  text = text.replace(/\[[^\]]*\]/g, "[redacted]")
 
   # Twitter length, then truncate with `...`
   limit = 140


### PR DESCRIPTION
Fixes the case of http://ayp.wtf.cat/at/1443214789468/ where only 1 redaction happens per line.

See https://jsfiddle.net/sgfco1za/