### PR TITLE
Let me emdash, bro

### DIFF
--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -92,7 +92,7 @@ module.exports = (robot) ->
     else
       msg.send msg.random karma.selfDeniedResponses(msg.message.user.name)
 
-  robot.hear /(?:[\(]([\S\s]+)[\)]|([\S]+[^()]))--(\s|$)/, (msg) ->
+  robot.hear /(?:[\(]([\S\s]+)[\)]|([\S]+[^()][^ ]))--(\s|$)/, (msg) ->
     subject = (msg.match[1] || msg.match[2]).toLowerCase()
     if allow_self is true or msg.message.user.name.toLowerCase() != subject
       karma.decrement subject

--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -84,7 +84,7 @@ module.exports = (robot) ->
   karma = new Karma robot
   allow_self = process.env.KARMA_ALLOW_SELF or "true"
 
-  robot.hear /(?:[\(]([\S\s]+)[\)]|([\S]+[^()]))\+\+(\s|$)/, (msg) ->
+  robot.hear /(?:[\(]([\S\s]+)[\)]|([\S]+[^()])[^ ])\+\+(\s|$)/, (msg) ->
     subject = (msg.match[1] || msg.match[2]).toLowerCase()
     if allow_self is true or msg.message.user.name.toLowerCase() != subject
       karma.increment subject


### PR DESCRIPTION
The karma script is picking up double-dashes in conversation as a negative karma vote (e.g. "I did a thing -- would not do again" causes `thing` to lose karma). This changes the listener's regular expression to ignore votes when there's a space immediately before `--` or `++`. 

One immediate downside is that it won't be possible to fix any votes already in Hayt's brain that have a trailing space using the karma script. 