### PR TITLE
I got spaces in all the wrong places

### DIFF
--- a/scripts/karma.coffee
+++ b/scripts/karma.coffee
@@ -84,7 +84,7 @@ module.exports = (robot) ->
   karma = new Karma robot
   allow_self = process.env.KARMA_ALLOW_SELF or "true"
 
-  robot.hear /(?:[\(]([\S\s]+)[\)]|([\S]+[^()])[^ ])\+\+(\s|$)/, (msg) ->
+  robot.hear /(?:[\(]([\S\s]+)[\)]|([\S]+[^() ]))\+\+(\s|$)/, (msg) ->
     subject = (msg.match[1] || msg.match[2]).toLowerCase()
     if allow_self is true or msg.message.user.name.toLowerCase() != subject
       karma.increment subject


### PR DESCRIPTION
Fixes an error where the regex match for karma++ was dropping the last letter of the thing being upvoted. 