### PR TITLE
Scram Kenny: 2017

### DIFF
--- a/scripts/ayp.coffee
+++ b/scripts/ayp.coffee
@@ -334,7 +334,7 @@ class AYPStrip
 
       if names.length == 1
         # The only person speaking is centered in the frame
-        char = avatars[names[0]]
+        char = avatars[names[0]].img
         left = (frame.width / 2) - (char.width / 2)
         top = (frame.height - char.height)
         @compositeImage frame, char, left, top
@@ -343,7 +343,7 @@ class AYPStrip
         first = true
         for line in lines
           [who, what] = line
-          char = avatars[who]
+          char = avatars[who].img
           top = (frame.height - char.height)
 
           if first
@@ -415,7 +415,7 @@ class AYPStrip
   ## Helpers and utilities
 
   # Load avatars for `names` and invoke `cb` as:
-  # `cb(err, {"Nickname": avatarImg, ...})`
+  # `cb(err, {"Nickname": {"img": avatarImg, "default": false}, ...})`
   # mapping each name to an avatar image that
   # can be used to represent it.
   #
@@ -446,7 +446,9 @@ class AYPStrip
           if names.every((o) -> o.img)
             avatars = {}
             for obj in names
-              avatars[obj.name] = obj.img
+              avatars[obj.name] =
+                img: obj.img
+                default: !!obj.img.match(/default\.png$/)
             cb(null, avatars)
 
   # Returns the bounding box of `msg`

--- a/scripts/ayp.coffee
+++ b/scripts/ayp.coffee
@@ -357,8 +357,22 @@ class AYPStrip
 
           @compositeImage frame, char, left, top
 
-      # Add the text after all the avatars are painted on
-      @drawPanelText frame, lines
+      # Helper for transforms below
+      # Randomly sort the words that were said
+      scramble = (what) ->
+        scrambleSort = -> 0.5 - Math.random()
+        what.split(' ').sort(scrambleSort).join(' ')
+
+      # Add the text after all the avatars are painted on, optionally
+      # transforming the spoken text for presentation
+      @drawPanelText frame, (
+        for line in lines
+          do (line) ->
+            [who, what] = line
+            # Scramble the words if this is the default avatar
+            what = scramble(what) if avatars[who].default
+            [who, what]
+      )
 
       # Return the frame to the caller
       return cb(false, frame)

--- a/scripts/ayp.coffee
+++ b/scripts/ayp.coffee
@@ -436,10 +436,15 @@ class AYPStrip
 
     for nameObj in names
       do (nameObj) ->
-        GD.openPng charPathForNick(nameObj.name), (err, img) ->
+        imgPath = charPathForNick(nameObj.name)
+        GD.openPng imgPath, (err, img) ->
           return if failed
           return fail(err) if err
-          nameObj.img = img unless err
+
+          # Store the actual image data in `.img` and
+          # the path to that data in `.imgPath`
+          nameObj.img = img
+          nameObj.imgPath = imgPath
 
           # Are we done? Then build up a dictionary
           # and tell the caller.
@@ -448,7 +453,7 @@ class AYPStrip
             for obj in names
               avatars[obj.name] =
                 img: obj.img
-                default: !!obj.img.match(/default\.png$/)
+                default: !!obj.imgPath.match(/default\.png$/)
             cb(null, avatars)
 
   # Returns the bounding box of `msg`

--- a/scripts/ayp.coffee
+++ b/scripts/ayp.coffee
@@ -525,7 +525,7 @@ class AYPStrip
 
   postToDisk: (cb) =>
     return cb(new Error("Nice try HACKERMAN. This does nothing unless you `$DEBUG`")) unless DEBUG
-    out_path = path.resolve(ROOT, "#{@info.when}.jpg")
+    out_path = path.resolve(ROOT, "ayp-DEBUG-#{@info.when}.jpg")
 
     @buildJPEG (jpg_err) =>
       return cb(jpg_err) if jpg_err


### PR DESCRIPTION
Follow @skalnik's work in https://github.com/desert-planet/hayt/pull/271 with work that, uh, works, and actually ran!

But using the same idea.

This also adds a `DEBUG=True` mode for ayp, toggled through `DEBUG` in the process env. If you use it inside of https://github.com/desert-planet/hayt-vagrant, you can generate local strips to inspect instead of just kinda hoping, or making trivial changes only.

### Now what?

  * [x] A debug mode
  * [x] A `default` flag for each dialog line
  * [x] Scramble the words in each `default` line
