### PR TITLE
Pin `irc-colors` to 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "hubot-fliptable": ">= 0.0.0",
     "hubot-google-images": "^0.2.6",
     "hubot-irc": "git+https://github.com/sshirokov/hubot-irc#arrakis",
+    "irc-colors": "1.1.0",
     "hubot-markov": "~1.3.0",
     "hubot-scripts": ">= 2.5.0 < 3.0.0",
     "node-gd": "~0.2.3",


### PR DESCRIPTION
The newer versions require a node that is >0.10, which we do not run.

This, turns out, is easier than upgrading most of node and hoping nothing breaks.