### PR TITLE
i forgor undefined 💀

### DIFF
--- a/scripts/remember.coffee
+++ b/scripts/remember.coffee
@@ -78,9 +78,12 @@ module.exports = (robot) ->
   robot.respond /forget\s+(.*)/i, (msg) ->
     key = msg.match[1].toLowerCase()
     value = memories()[key]
-    delete memories()[key]
-    delete memoriesByRecollection()[key]
-    msg.send "I've forgotten #{key} is #{value}."
+    if value
+      delete memories()[key]
+      delete memoriesByRecollection()[key]
+      msg.send "I've forgotten #{key} is #{value}."
+    else
+      msg.send "I don't remember anything matching `#{key}`... so we're probably all good?"
 
   robot.respond /what are your favorite memories/i, (msg) ->
     msg.finish()

--- a/scripts/remember.coffee
+++ b/scripts/remember.coffee
@@ -75,8 +75,6 @@ module.exports = (robot) ->
       else
         msg.send "I don't remember #{key}, but I'll remember it now!"
 
-      msg.send value
-
   robot.respond /forget\s+(.*)/i, (msg) ->
     key = msg.match[1].toLowerCase()
     value = memories()[key]

--- a/scripts/remember.coffee
+++ b/scripts/remember.coffee
@@ -2,12 +2,13 @@
 #   Remembers a key and value
 #
 # Commands:
-#   hubot what is|remember <key> - Returns a string
-#   hubot remember <key> is <value>. - Returns nothing. Remembers the text for next time!
-#   hubot what do you remember - Returns everything hubot remembers.
+#   hubot rem|remember|what is <key> - Returns a string.
+#   hubot rem|remember <key> is <value> - Returns nothing. Remembers the text for next time!
+#   hubot replace <key> with <value> - Returns nothing. Replaces an existing memory with new text.
 #   hubot forget <key> - Removes key from hubots brain.
-#   hubot what are your favorite memories? - Returns a list of the most remembered memories.  
-#   hubot random memory - Returns a random string
+#   hubot what are your favorite memories? - Returns a list of the most remembered memories.
+#   hubot me|random memory - Returns a random memory.
+#   hubot me|random memory <prefix> - Returns a random memory whose key matches the prefix.
 #
 # Dependencies:
 #   "underscore": "*"
@@ -30,7 +31,7 @@ module.exports = (robot) ->
       value = match[3]
       currently = memories()[key]
       if currently
-        msg.send "But #{key} is already #{currently}.  Forget #{key} first."
+        msg.send "But #{key} is already #{currently}. Use `replace` to update existing memories."
       else
         memories()[key] = value
         msg.send "OK, I'll remember #{key}."
@@ -58,6 +59,21 @@ module.exports = (robot) ->
             value = "I don't remember `#{key}`. Did you mean:\n#{keys}"
           else
             value = "I don't remember anything matching `#{key}`"
+
+      msg.send value
+
+  robot.respond /replace\s+(.*)/i, (msg) ->
+    words = msg.match[1].trim()
+    if match = words.match /(.*?)(\s+with\s+([\s\S]*))$/i
+      msg.finish()
+      key = match[1].toLowerCase()
+      value = match[3]
+      currently = memories()[key]
+      memories()[key] = value
+      if currently
+        msg.send "OK, #{key} has been updated."
+      else
+        msg.send "I don't remember #{key}, but I'll remember it now!"
 
       msg.send value
 

--- a/tests/rem_test.coffee
+++ b/tests/rem_test.coffee
@@ -1,0 +1,20 @@
+Helper = require('hubot-test-helper')
+
+helper = new Helper('../scripts/loud.coffee')
+expect = require('chai').expect
+
+describe 'remembering things', ->
+  room = null
+  memoriesByRecollection = () -> room.robot.brain.data.memoriesByRecollection ?= {}
+  memories = () -> room.robot.brain.data.remember ?= {}
+
+  beforeEach ->
+    room = helper.createRoom()
+
+  it 'should remember things', ->
+    room.user.say 'alice', '@hubot rem key is value', ->
+      expect(room.messages).to.eql [
+        ['alice', '@hubot rem key is value']
+        ['hubot', 'Okay, I\'ll remember key']
+      ]
+      expect(room.robot.brain.data.remember['key']).to.eql 'value'

--- a/tests/rem_test.coffee
+++ b/tests/rem_test.coffee
@@ -38,6 +38,10 @@ describe '.rem/.replace', ->
     expect(lastResponse()).to.eql ['hubot', 'I\'ve forgotten key is value.']
     expect(room.robot.brain.data.remember['key']).to.eql undefined
 
+    # Make sure we respond correctly if no such key exists.
+    room.user.say 'alice', '@hubot forget key'
+    expect(lastResponse()).to.eql ['hubot', "I don't remember anything matching `key`... so we're probably all good?"]
+
   it 'should not hallucinate memories', ->
     room.user.say 'alice', '@hubot rem key'
 

--- a/tests/rem_test.coffee
+++ b/tests/rem_test.coffee
@@ -1,20 +1,45 @@
 Helper = require('hubot-test-helper')
 
-helper = new Helper('../scripts/loud.coffee')
+helper = new Helper('../scripts/remember.coffee')
 expect = require('chai').expect
 
-describe 'remembering things', ->
+describe '.rem/.replace', ->
   room = null
-  memoriesByRecollection = () -> room.robot.brain.data.memoriesByRecollection ?= {}
-  memories = () -> room.robot.brain.data.remember ?= {}
+
+  lastResponse = () -> room.messages[room.messages.length - 1]
 
   beforeEach ->
     room = helper.createRoom()
 
   it 'should remember things', ->
-    room.user.say 'alice', '@hubot rem key is value', ->
-      expect(room.messages).to.eql [
-        ['alice', '@hubot rem key is value']
-        ['hubot', 'Okay, I\'ll remember key']
-      ]
-      expect(room.robot.brain.data.remember['key']).to.eql 'value'
+    # Test that we can create a new memory.
+    room.user.say 'alice', '@hubot rem key is value'
+
+    expect(lastResponse()).to.eql ['hubot', 'OK, I\'ll remember key.']
+    expect(room.robot.brain.data.remember['key']).to.eql 'value'
+
+    # Test recalling the new memory.
+    room.user.say 'alice', '@hubot rem key'
+    expect(lastResponse()).to.eql ['hubot', 'value']
+
+  it 'should be able to update memories', ->
+    # Create a new memory `key` and then update its value.
+    room.user.say 'alice', '@hubot rem key is value'
+    room.user.say 'alice', '@hubot replace key with a different value'
+
+    expect(lastResponse()).to.eql ['hubot', 'OK, key has been updated.']
+    expect(room.robot.brain.data.remember['key']).to.eql 'a different value'
+
+  it 'should be able to forget memories', ->
+    # Create a new memory `key` and then try to forget it.
+    room.user.say 'alice', '@hubot rem key is value'
+    room.user.say 'alice', '@hubot forget key'
+
+    expect(lastResponse()).to.eql ['hubot', 'I\'ve forgotten key is value.']
+    expect(room.robot.brain.data.remember['key']).to.eql undefined
+
+  it 'should not hallucinate memories', ->
+    room.user.say 'alice', '@hubot rem key'
+
+    expect(lastResponse()).to.eql ['hubot', 'I don\'t remember anything matching `key`']
+    expect(room.robot.brain.data.remember['key']).to.eql undefined


### PR DESCRIPTION
> NOTE: This PR is meant to be merged after #384, so only the last commit in this PR is actually new. Once #384 gets merged this PR should automatically show only the one new commit.

When using `.forget` to forget a memory that doesn't exist, the current message is... not ideal:

```txt
12:21 PM <randomPoison> .forget asdlkasdjf
12:21 PM <@Hayt> I've forgotten asdlkasdjf is undefined.
12:21 PM <randomPoison> nice
```

This PR updates the message to one that more directly calls out that they key doesn't exist, which should help people realize when they typed in the wrong key name.