### PR TITLE
Fix .me regex to not break from a trailing space

### DIFF
--- a/scripts/remember.coffee
+++ b/scripts/remember.coffee
@@ -76,7 +76,7 @@ module.exports = (robot) ->
 
     msg.send "My favorite memories are:\n#{sortedMemories[0..20].join(', ')}"
 
-  robot.respond /(me|random memory)(\s+.+)?$/i, (msg) ->
+  robot.respond /(me|random memory)(\s+.*)?$/i, (msg) ->
     msg.finish()
 
     randomKey = if msg.match[2]

--- a/scripts/remember.coffee
+++ b/scripts/remember.coffee
@@ -79,7 +79,7 @@ module.exports = (robot) ->
   robot.respond /(me|random memory)(\s+.*)?$/i, (msg) ->
     msg.finish()
 
-    search = msg.match[2].trim()
+    search = msg.match[2]?.trim()
     randomKey = if search
       msg.random(findSimilarMemories(search))
     else

--- a/scripts/remember.coffee
+++ b/scripts/remember.coffee
@@ -79,8 +79,9 @@ module.exports = (robot) ->
   robot.respond /(me|random memory)(\s+.*)?$/i, (msg) ->
     msg.finish()
 
-    randomKey = if msg.match[2]
-      msg.random(findSimilarMemories(msg.match[2].trim()))
+    search = msg.match[2].trim()
+    randomKey = if search
+      msg.random(findSimilarMemories(search))
     else
       msg.random(Object.keys(memories()))
 


### PR DESCRIPTION
The original regex expectes either 0 or at least 2 characters after the `.me` in order for the regex to match. This made it so that a single trailing space after `.me` would cause the regex to not match. Changing `.+` to `.*` allows the second capture group to match a single trailing space.