### PR TITLE
Allow keys to contain "is" and "?"

### DIFF
--- a/scripts/remember.coffee
+++ b/scripts/remember.coffee
@@ -23,43 +23,52 @@ module.exports = (robot) ->
     Object.keys(memories()).filter (key) -> searchRegex.test(key)
 
   robot.respond /(?:what is|rem(?:ember)?)\s+(.*)/i, (msg) ->
+    msg.finish()
     words = msg.match[1].trim()
-    if match = words.match /(.*?)(\s+is\s+([\s\S]*))$/i
-      msg.finish()
-      key = match[1].toLowerCase()
-      value = match[3]
-      currently = memories()[key]
-      if currently
-        msg.send "But #{key} is already #{currently}.  Forget #{key} first."
-      else
-        memories()[key] = value
-        msg.send "OK, I'll remember #{key}."
-    else if match = words.match /([^?]+)\??/i
-      msg.finish()
 
+    # First check for a search expression.
+    if match = words.match /\|\s*(grep\s+)?(.*)$/i
+      searchPattern = match[2]
+      matchingKeys = findSimilarMemories(searchPattern)
+      if matchingKeys.length > 0
+        msg.send "I remember:\n#{matchingKeys.join(', ')}"
+      else
+        msg.send "I don't remember anything matching `#{searchPattern}`"
+      return
+
+    # Next, attempt to interpret `words` as an existing key.
+    if match = words.match /([^?]+)\??/i
       key = match[1].toLowerCase()
       value = memories()[key]
 
       if value
         memoriesByRecollection()[key] ?= 0
         memoriesByRecollection()[key]++
-      else
-        if match = words.match /\|\s*(grep\s+)?(.*)$/i
-          searchPattern = match[2]
-          matchingKeys = findSimilarMemories(searchPattern)
-          if matchingKeys.length > 0
-            value = "I remember:\n#{matchingKeys.join(', ')}"
-          else
-            value = "I don't remember anything matching `#{searchPattern}`"
-        else
-          matchingKeys = findSimilarMemories(key)
-          if matchingKeys.length > 0
-            keys = matchingKeys.join(', ')
-            value = "I don't remember `#{key}`. Did you mean:\n#{keys}"
-          else
-            value = "I don't remember anything matching `#{key}`"
+        msg.send value
+        return
 
-      msg.send value
+    # Next, attempt to interpret `words` as a "foo is bar" expression in order
+    # to store a memory.
+    if match = words.match /^(.*)is(.*)$/i
+      key = match[1].trim().toLowerCase()
+      value = match[2].trim()
+      if key and value
+        currently = memories()[key]
+        if currently
+          msg.send "But #{key} is already #{currently}.  Forget #{key} first."
+        else
+          memories()[key] = value
+          msg.send "OK, I'll remember #{key}."
+        return
+
+    # If none of the previous actions succeeded, search existing memories for
+    # similar keys.
+    matchingKeys = findSimilarMemories(words)
+    if matchingKeys.length > 0
+      keys = matchingKeys.join(', ')
+      msg.send "I don't remember `#{words}`. Did you mean:\n#{keys}"
+    else
+      msg.send "I don't remember anything matching `#{words}`"
 
   robot.respond /forget\s+(.*)/i, (msg) ->
     key = msg.match[1].toLowerCase()

--- a/scripts/remember.coffee
+++ b/scripts/remember.coffee
@@ -36,14 +36,15 @@ module.exports = (robot) ->
         msg.send "I don't remember anything matching `#{searchPattern}`"
       return
 
-    # Next, attempt to interpret `words` as an existing key.
-    if match = words.match /([^?]+)\??/i
-      key = match[1].toLowerCase()
-      value = memories()[key]
+    # Next, attempt to interpret `words` as an existing key. This also strips
+    # off the last "?" character.
+    if match = words.match /(.+?)\??$/i
+      stripped_key = match[1].toLowerCase()
+      value = memories()[stripped_key]
 
       if value
-        memoriesByRecollection()[key] ?= 0
-        memoriesByRecollection()[key]++
+        memoriesByRecollection()[stripped_key] ?= 0
+        memoriesByRecollection()[stripped_key]++
         msg.send value
         return
 
@@ -63,12 +64,12 @@ module.exports = (robot) ->
 
     # If none of the previous actions succeeded, search existing memories for
     # similar keys.
-    matchingKeys = findSimilarMemories(words)
+    matchingKeys = findSimilarMemories(stripped_key)
     if matchingKeys.length > 0
       keys = matchingKeys.join(', ')
-      msg.send "I don't remember `#{words}`. Did you mean:\n#{keys}"
+      msg.send "I don't remember `#{stripped_key}`. Did you mean:\n#{keys}"
     else
-      msg.send "I don't remember anything matching `#{words}`"
+      msg.send "I don't remember anything matching `#{stripped_key}`"
 
   robot.respond /forget\s+(.*)/i, (msg) ->
     key = msg.match[1].toLowerCase()


### PR DESCRIPTION
Add support for having "is" in the key for memories, allowing us to save memories with names like "why is it going down". In order to support this, I've had to refactor the handler to change the order of the operations performed by the handler.

The reason that is necessary is because the current logic makes it so you can never retrieve a key that contains "is". For example, if we had a memory named "a is b", we would try to retrieve it with `.rem a is b`. But this will be interpreted as a request to create a new memory "a" with the value "b". To make it possible to have "is" in the key, we need to first check if the entire phrase matches an existing key. If it doesn't, we can then attempt to interpret it as a request to store a new key.

I also changed the handling of "?", allowing keys containing "?" to be remembered. The current logic will only use the text before the first "?", so if you tried to remember a key named "hello?" it would always instead search for a memory named "hello". This PR changes the logic to instead use the text up to the last "?". This means that searching for "hello?" will still look for a memory named "hello". But you can search for keys that contain a "?" but adding an extra "?" at the end, i.e. you'd do `.rem hello??` to retrieve the key "hello?".