### PR TITLE
Don't allow empty roles

### DIFF
--- a/scripts/roles.coffee
+++ b/scripts/roles.coffee
@@ -47,25 +47,27 @@ module.exports = (robot) ->
     name    = msg.match[1].trim()
     newRole = msg.match[2].trim()
 
-    unless name in ['', 'who', 'what', 'where', 'when', 'why']
-      unless newRole.match(/^not\s+/i)
-        users = robot.brain.usersForFuzzyName(name)
-        if users.length is 1
-          user = users[0]
-          user.roles = user.roles or [ ]
+    return if name in ['', 'who', 'what', 'where', 'when', 'why']
+    return if newRole is ''
+    return if newRole.match(/^not\s+/i)
 
-          if newRole in user.roles
-            msg.send "I know"
-          else
-            user.roles.push(newRole)
-            if name.toLowerCase() is robot.name.toLowerCase()
-              msg.send "Ok, I am #{newRole}."
-            else
-              msg.send "Ok, #{name} is #{newRole}."
-        else if users.length > 1
-          msg.send getAmbiguousUserText users
+    users = robot.brain.usersForFuzzyName(name)
+    if users.length is 1
+      user = users[0]
+      user.roles = user.roles or [ ]
+
+      if newRole in user.roles
+        msg.send "I know"
+      else
+        user.roles.push(newRole)
+        if name.toLowerCase() is robot.name.toLowerCase()
+          msg.send "Ok, I am #{newRole}."
         else
-          msg.send "I don't know anything about #{name}."
+          msg.send "Ok, #{name} is #{newRole}."
+    else if users.length > 1
+      msg.send getAmbiguousUserText users
+    else
+      msg.send "I don't know anything about #{name}."
 
   robot.respond /@?([\w .\-_]+) is not (["'\w: \-_]+)[.!]*$/i, (msg) ->
     name    = msg.match[1].trim()

--- a/tests/roles_test.coffee
+++ b/tests/roles_test.coffee
@@ -13,6 +13,7 @@ describe 'roles management', ->
     # automatically.
     room.robot.brain.userForId('1', name: 'alice')
     room.robot.brain.userForId('2', name: 'bob')
+    room.robot.brain.userForId('3', name: 'charlie')
 
   context 'assigning roles', ->
     it 'should assign a role to a user', ->
@@ -21,3 +22,138 @@ describe 'roles management', ->
       bob = room.robot.brain.userForName('bob')
       expect(bob.roles).to.contain 'a badass guitarist'
       expect(room.messages[1][1]).to.eql 'Ok, bob is a badass guitarist.'
+
+    it 'should assign multiple roles to the same user', ->
+      room.user.say 'alice', '@hubot bob is a badass guitarist'
+      room.user.say 'alice', '@hubot bob is a coffee enthusiast'
+
+      bob = room.robot.brain.userForName('bob')
+      expect(bob.roles).to.contain 'a badass guitarist'
+      expect(bob.roles).to.contain 'a coffee enthusiast'
+      expect(room.messages[1][1]).to.eql 'Ok, bob is a badass guitarist.'
+      expect(room.messages[3][1]).to.eql 'Ok, bob is a coffee enthusiast.'
+
+    it 'should acknowledge when a user already has the role', ->
+      room.user.say 'alice', '@hubot bob is a badass guitarist'
+      room.user.say 'alice', '@hubot bob is a badass guitarist'
+
+      bob = room.robot.brain.userForName('bob')
+      expect(bob.roles).to.contain 'a badass guitarist'
+      expect(bob.roles.length).to.eql 1
+      expect(room.messages[1][1]).to.eql 'Ok, bob is a badass guitarist.'
+      expect(room.messages[3][1]).to.eql 'I know'
+
+    it 'should not assign roles for reserved words', ->
+      room.user.say 'alice', '@hubot who is a person'
+      room.user.say 'alice', '@hubot what is happening'
+      room.user.say 'alice', '@hubot where is the location'
+
+      # Only "who is" should get a response, "what" and "where" should be ignored
+      expect(room.messages.length).to.eql 4  # 3 user messages + 1 robot response
+      expect(room.messages[1][1]).to.eql "a person? Never heard of 'em"
+
+    it 'should handle unknown users', ->
+      room.user.say 'alice', '@hubot unknown_user is a mystery'
+      expect(room.messages[1][1]).to.eql "I don't know anything about unknown_user."
+
+    # lmao this is less of a test case and more of a bug report.
+    it 'should handle empty role assignments gracefully', ->
+      room.user.say 'alice', '@hubot bob is '
+
+      bob = room.robot.brain.userForName('bob')
+      expect(bob.roles).to.contain ''
+      expect(room.messages[1][1]).to.eql 'Ok, bob is .'
+
+  context 'removing roles', ->
+    beforeEach ->
+      # Give bob some initial roles.
+      bob = room.robot.brain.userForName('bob')
+      bob.roles = ['a badass guitarist', 'a coffee enthusiast', 'a code reviewer']
+
+    it 'should remove a role from a user', ->
+      room.user.say 'alice', '@hubot bob is not a badass guitarist'
+
+      bob = room.robot.brain.userForName('bob')
+      expect(bob.roles).to.not.contain 'a badass guitarist'
+      expect(bob.roles).to.contain 'a coffee enthusiast'
+      expect(bob.roles).to.contain 'a code reviewer'
+      expect(room.messages[1][1]).to.eql 'Ok, bob is no longer a badass guitarist.'
+
+    it 'should acknowledge when trying to remove a role the user does not have', ->
+      room.user.say 'alice', '@hubot bob is not a ninja'
+
+      bob = room.robot.brain.userForName('bob')
+      expect(bob.roles).to.eql ['a badass guitarist', 'a coffee enthusiast', 'a code reviewer']
+      expect(room.messages[1][1]).to.eql 'I know.'
+
+    it 'should prevent users from removing their own roles', ->
+      room.user.say 'bob', '@hubot bob is not a badass guitarist'
+
+      bob = room.robot.brain.userForName('bob')
+      expect(bob.roles).to.contain 'a badass guitarist'
+      expect(room.messages[1][1]).to.eql '@bob Nice try, buddy.'
+
+    it 'should handle unknown users when removing roles', ->
+      room.user.say 'alice', '@hubot unknown_user is not a mystery'
+      expect(room.messages[1][1]).to.eql "I don't know anything about unknown_user."
+
+  context 'querying roles', ->
+    beforeEach ->
+      # Set up some users with different role configurations.
+      bob = room.robot.brain.userForName('bob')
+      bob.roles = ['a badass guitarist', 'a coffee enthusiast']
+
+      charlie = room.robot.brain.userForName('charlie')
+      charlie.roles = ['a developer, tester, and debugger', 'a team lead']
+
+    it 'should list all roles for a user', ->
+      room.user.say 'alice', '@hubot who is bob'
+      expect(room.messages[1][1]).to.eql 'bob is a badass guitarist, a coffee enthusiast.'
+
+    it 'should handle users with no roles', ->
+      room.user.say 'alice', '@hubot who is alice'
+      expect(room.messages[1][1]).to.eql 'alice is nothing to me.'
+
+    it 'should use semicolons when roles contain commas', ->
+      room.user.say 'alice', '@hubot who is charlie'
+      expect(room.messages[1][1]).to.eql 'charlie is a developer, tester, and debugger; a team lead.'
+
+    it 'should handle the special case "who is you"', ->
+      room.user.say 'alice', '@hubot who is you'
+      expect(room.messages[1][1]).to.eql "Who ain't I?"
+
+    it 'should handle asking about the robot by name', ->
+      room.user.say 'alice', '@hubot who is hubot'
+      expect(room.messages[1][1]).to.eql "The best."
+
+    it 'should handle unknown users', ->
+      room.user.say 'alice', '@hubot who is unknown_user'
+      expect(room.messages[1][1]).to.eql "unknown_user? Never heard of 'em"
+
+    it 'should handle question marks in queries', ->
+      room.user.say 'alice', '@hubot who is bob?'
+      expect(room.messages[1][1]).to.eql 'bob is a badass guitarist, a coffee enthusiast.'
+
+  context 'user disambiguation', ->
+    beforeEach ->
+      # Add charlie_smith for ambiguity testing with charlie.
+      room.robot.brain.userForId('4', name: 'charlie_smith')
+
+    it 'should handle ambiguous usernames when assigning roles', ->
+      room.user.say 'alice', '@hubot char is a developer'
+      expect(room.messages[1][1]).to.contain 'Be more specific, I know 2 people named like that: charlie, charlie_smith'
+
+    it 'should handle ambiguous usernames when removing roles', ->
+      room.user.say 'alice', '@hubot char is not a developer'
+      expect(room.messages[1][1]).to.contain 'Be more specific, I know 2 people named like that: charlie, charlie_smith'
+
+    it 'should handle ambiguous usernames when querying roles', ->
+      room.user.say 'alice', '@hubot who is char'
+      expect(room.messages[1][1]).to.contain 'Be more specific, I know 2 people named like that: charlie, charlie_smith'
+
+    it 'should work with exact username matches', ->
+      room.user.say 'alice', '@hubot charlie is a specific user'
+
+      charlie = room.robot.brain.userForName('charlie')
+      expect(charlie.roles).to.contain 'a specific user'
+      expect(room.messages[1][1]).to.eql 'Ok, charlie is a specific user.'

--- a/tests/roles_test.coffee
+++ b/tests/roles_test.coffee
@@ -1,0 +1,23 @@
+Helper = require('hubot-test-helper')
+expect = require('chai').expect
+
+helper = new Helper('../scripts/roles.coffee')
+
+describe 'roles management', ->
+  room = null
+
+  beforeEach ->
+    room = helper.createRoom()
+
+    # Manually create users in the brain since the test helper doesn't do it
+    # automatically.
+    room.robot.brain.userForId('1', name: 'alice')
+    room.robot.brain.userForId('2', name: 'bob')
+
+  context 'assigning roles', ->
+    it 'should assign a role to a user', ->
+      room.user.say 'alice', '@hubot bob is a badass guitarist'
+
+      bob = room.robot.brain.userForName('bob')
+      expect(bob.roles).to.contain 'a badass guitarist'
+      expect(room.messages[1][1]).to.eql 'Ok, bob is a badass guitarist.'

--- a/tests/roles_test.coffee
+++ b/tests/roles_test.coffee
@@ -56,13 +56,14 @@ describe 'roles management', ->
       room.user.say 'alice', '@hubot unknown_user is a mystery'
       expect(room.messages[1][1]).to.eql "I don't know anything about unknown_user."
 
-    # lmao this is less of a test case and more of a bug report.
     it 'should handle empty role assignments gracefully', ->
       room.user.say 'alice', '@hubot bob is '
 
       bob = room.robot.brain.userForName('bob')
-      expect(bob.roles).to.contain ''
-      expect(room.messages[1][1]).to.eql 'Ok, bob is .'
+      # Should not assign empty roles.
+      expect(bob.roles or []).to.not.contain ''
+      # Should not respond to empty role assignments.
+      expect(room.messages.length).to.eql 1
 
   context 'removing roles', ->
     beforeEach ->

--- a/tests/roles_test.coffee
+++ b/tests/roles_test.coffee
@@ -48,7 +48,7 @@ describe 'roles management', ->
       room.user.say 'alice', '@hubot what is happening'
       room.user.say 'alice', '@hubot where is the location'
 
-      # Only "who is" should get a response, "what" and "where" should be ignored
+      # Only "who is" should get a response, "what" and "where" should be ignored.
       expect(room.messages.length).to.eql 4  # 3 user messages + 1 robot response
       expect(room.messages[1][1]).to.eql "a person? Never heard of 'em"
 


### PR DESCRIPTION
So I was writing tests for the roles script and stumbled across a fun feature: If you do ".alice is " (note the trailing space), then alice is forever branded by the cursed "" empty role. We smartly trim whitespace on the role text, but then fail to see if there's anything left in the string v__v

Don't be fooled! The diff in `roles.coffeescript` looks pretty gnarly with whitespace diffing enabled, but if you disable whitespace then you can see that for most of it only changed indentation. Since I was adding one more validation step, I decided to turn the 3 `unless`es into 3 early returns (love an early return). This reduces indentation, which may or may not be a good thing to you idk ur kinks.